### PR TITLE
Add offline taxonomy rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,16 @@ This repo contains a small script that crawls the public Dynatrace documentation
 
 ## Usage
 
-Run the following command:
+Run the following command to crawl the live documentation site:
 
 ```bash
 python generate_docs_hierarchy.py
+```
+
+If you already have a predefined taxonomy (for example `startertaxonomy.json`), you can generate the hierarchy offline:
+
+```bash
+python generate_docs_hierarchy.py --taxonomy startertaxonomy.json --output taxonomy.html
 ```
 
 The script retrieves the Dynatrace documentation pages starting from `https://docs.dynatrace.com/docs`, builds a nested structure, and then writes:


### PR DESCRIPTION
## Summary
- extend `generate_docs_hierarchy.py` with ability to load a taxonomy JSON
- document new `--taxonomy` option in README

## Testing
- `python -m py_compile generate_docs_hierarchy.py`
- `python generate_docs_hierarchy.py --taxonomy startertaxonomy.json --output taxonomy.html`

------
https://chatgpt.com/codex/tasks/task_e_6878676e023483239dadfc7a5440fbc3