### PR TITLE
Support export and import of internal links

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The script retrieves the Dynatrace documentation pages starting from `https://do
 - `docs_hierarchy.json` – a JSON representation of the hierarchy
 - `docs_hierarchy.html` – an interactive webpage listing pages with placeholder internal links
 
-Open `docs_hierarchy.html` in your browser to explore the hierarchy.
+Open `docs_hierarchy.html` in your browser to explore the hierarchy. The page stores any internal links you add in your browser's `localStorage`. Use the **Export Links** and **Import Links** buttons to save them to disk or load them back later.
 
 ## Limitations
 


### PR DESCRIPTION
## Summary
- allow exporting and importing internal links via file download
- document new manual persistence workflow in README

## Testing
- `python -m py_compile generate_docs_hierarchy.py`
- `python generate_docs_hierarchy.py --taxonomy dynatrace_fast_taxonomy.json --output test.html`

------
https://chatgpt.com/codex/tasks/task_e_68789a95ac4c83239a69c61e83bd067c