### PR TITLE
Add remote link storage server

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repo contains a small script that crawls the public Dynatrace documentation
 
 - Python 3.12+
 - `requests` and `beautifulsoup4` (`pip install requests beautifulsoup4`)
+- `Flask` and `Flask-CORS` if you want to use the optional storage server
 
 ## Usage
 
@@ -27,6 +28,24 @@ The script retrieves the Dynatrace documentation pages starting from `https://do
 - `docs_hierarchy.html` – an interactive webpage listing pages with placeholder internal links
 
 Open `docs_hierarchy.html` in your browser to explore the hierarchy. The page stores any internal links you add in your browser's `localStorage`. Use the **Export Links** and **Import Links** buttons to save them to disk or load them back later.
+
+### Using external storage
+
+You can run a small Flask server to keep the internal links centrally so that every browser sees the same data. First install the dependencies and start the server:
+
+```bash
+pip install Flask Flask-CORS
+python storage_server.py
+```
+
+Then generate the HTML pointing at the server:
+
+```bash
+python generate_docs_hierarchy.py --taxonomy dynatrace_fast_taxonomy.json \
+  --output docs_hierarchy.html --server-url http://localhost:5000
+```
+
+When opened in the browser, the page will load and save links via that server instead of `localStorage`.
 
 ## Limitations
 

--- a/storage_server.py
+++ b/storage_server.py
@@ -1,0 +1,51 @@
+from flask import Flask, request, jsonify
+from flask_cors import CORS
+import json
+from pathlib import Path
+
+app = Flask(__name__)
+CORS(app)
+
+DATA_FILE = Path('stored_links.json')
+
+def read_store():
+    if DATA_FILE.is_file():
+        try:
+            with DATA_FILE.open() as f:
+                return json.load(f)
+        except Exception:
+            return {}
+    return {}
+
+def write_store(store):
+    with DATA_FILE.open('w') as f:
+        json.dump(store, f)
+
+@app.route('/links/<path:url>', methods=['GET'])
+def get_links(url):
+    store = read_store()
+    return jsonify(store.get(url, []))
+
+@app.route('/links/<path:url>', methods=['POST'])
+def save_links(url):
+    store = read_store()
+    store[url] = request.get_json(force=True, silent=True) or []
+    write_store(store)
+    return jsonify({'status': 'ok'})
+
+@app.route('/links', methods=['GET'])
+def get_all():
+    return jsonify(read_store())
+
+@app.route('/links', methods=['POST'])
+def save_all():
+    store = request.get_json(force=True, silent=True) or {}
+    write_store(store)
+    return jsonify({'status': 'ok'})
+
+@app.route('/ping')
+def ping():
+    return 'pong'
+
+if __name__ == '__main__':
+    app.run(port=5000)


### PR DESCRIPTION
## Summary
- add Flask-based storage server for centralized link storage
- support optional `--server-url` in docs HTML generator
- update README with external storage instructions

## Testing
- `python -m py_compile generate_docs_hierarchy.py`
- `python generate_docs_hierarchy.py --taxonomy dynatrace_fast_taxonomy.json --output docs_hierarchy.html --server-url http://localhost:5000`

------
https://chatgpt.com/codex/tasks/task_e_68789e2128b883238656ab4dcfe0cc66